### PR TITLE
fixed conference dates and a typo

### DIFF
--- a/actdocs/conf/act.ini
+++ b/actdocs/conf/act.ini
@@ -40,8 +40,8 @@ sender_address =  info@gpw2015.de
 
 [talks]
 # conference dates
-start_date = 2015-03-25 18:00:00
-end_date   = 2015-03-28 16:00:00
+start_date = 2015-05-05 18:00:00
+end_date   = 2015-05-08 16:00:00
 
 # default talk durations
 durations = 10 20 40
@@ -63,7 +63,7 @@ edition_open  = 1
 show_schedule = 1
 
 # schedule date to show when none specified
-schedule_default = 2015-03-25
+schedule_default = 2015-05-06
 
 # show accepted talks, or all
 show_all  = 0
@@ -85,7 +85,7 @@ level2_name_en = Beginner
 level2_name_de = Anfänger
 
 level3_name_de = Fortgeschrittene
-level3_name_en = Fortgeschrittene
+level3_name_en = Intermediate
 
 level4_name_de = Mit Thema vertraut
 level4_name_en = Familar with subject


### PR DESCRIPTION
Für den Workshop 2014 war der Start bereits einen Tag vorher um 18 Uhr, ich habe das mal so gelassen und die Daten angepasst.
