### PR TITLE
"Invoice" umwandeln in Bestellschein

### DIFF
--- a/actdocs/payment/invoice
+++ b/actdocs/payment/invoice
@@ -16,7 +16,7 @@ Homepage: http://frankfurt.pm<br>
         <td colspan="2">
           <table border="0">
             <tr>
-              <td><b>{{Invoice #}}</b></td>
+              <td><b>Bestellschein</b></td>
               <td>[% invoice.invoice_no %]</td>
             </tr>
             <tr>
@@ -94,7 +94,7 @@ Homepage: http://frankfurt.pm<br>
             <tr valign="top"> <td> Verwendungszweck</td><td>DPW 2015 Dresden<br/>BestellNr.: <em>Bestellnummer</em><br/><em>Nachname, Vorname</em></td></tr>
             <tr> 
 	      <td colspan="2">
-	      <p>Der Frankfurt Perlmongers e.V. ist ein gemeinn&uuml;tziger Verein weisst keine USt. aus.</p>
+	      <p>Der Frankfurt Perlmongers e.V. ist ein gemeinn&uuml;tziger Verein. Die Rechnung mit ausgewiesener Mehrwertsteuer erhalten Sie von vorstand@frankfurt.pm .</p>
 	    </tr>
           </table>
         </td>


### PR DESCRIPTION
Da wir die Rechnungen mit ausgewiesener Mehrwertsteuer separat erstellen, sollte die Webseite keine eigene Rechnung erstellen.
