### PR TITLE
add link to wiki in menu

### DIFF
--- a/actdocs/templates/menu
+++ b/actdocs/templates/menu
@@ -10,8 +10,8 @@
 
     <li class="section"><a href="[% make_uri('hotels.html') %]"><t><de>Hotels</de><en>Hotels</en></t></a></li>
     <li class="section"><a href="[% make_uri('dresden.html') %]">Dresden</a></li>
+    <li class="section"><a href="[% make_uri('wiki') %]">Wiki</a></li>
 
-    [%# PROCESS menus/wiki %]
     [% PROCESS menus/talks %]
 
 [% END %]


### PR DESCRIPTION
Users often use the wiki to publish infos about arrival/leave dates and so on...
